### PR TITLE
Move calendar card to bottom of dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -226,11 +226,7 @@ function App() {
     updatePIN: updatePIN
   })))), /*#__PURE__*/React.createElement("main", {
     className: "mx-auto max-w-5xl px-4 py-6 grid gap-6"
-  }, /*#__PURE__*/React.createElement(TopNav, {
-    date: date,
-    setDate: setDate,
-    data: data
-  }), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("div", {
     className: "grid md:grid-cols-3 gap-6"
   }, /*#__PURE__*/React.createElement(Card, {
     title: "Morning"
@@ -382,7 +378,11 @@ function App() {
     onClick: resetApp
   }, "Reset App (export \u2192 clear \u2192 reload)"), /*#__PURE__*/React.createElement("p", {
     className: "text-xs text-zinc-500"
-  }, "This will optionally back up your data as JSON, then clear local storage and unregister the service worker before reloading.")))), /*#__PURE__*/React.createElement("footer", {
+  }, "This will optionally back up your data as JSON, then clear local storage and unregister the service worker before reloading.")))), /*#__PURE__*/React.createElement(TopNav, {
+    date: date,
+    setDate: setDate,
+    data: data
+  }), /*#__PURE__*/React.createElement("footer", {
     className: "pt-2 pb-8 text-center text-xs text-zinc-500 dark:text-zinc-400"
   }, "Built for Mark \u2014 \u201Csee clearly, return gently, offer everything to Christ.\u201D")));
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -195,8 +195,6 @@ function App() {
       </header>
 
       <main className="mx-auto max-w-5xl px-4 py-6 grid gap-6">
-        <TopNav date={date} setDate={setDate} data={data} />
-
         <div className="grid md:grid-cols-3 gap-6">
           <Card title="Morning">
             <ToggleRow
@@ -323,6 +321,8 @@ function App() {
             </div>
           </Card>
         </div>
+
+        <TopNav date={date} setDate={setDate} data={data} />
 
         <footer className="pt-2 pb-8 text-center text-xs text-zinc-500 dark:text-zinc-400">
           Built for Mark — “see clearly, return gently, offer everything to Christ.”


### PR DESCRIPTION
## Summary
- move the calendar/navigation card to the bottom of the main dashboard grid so it appears after the other sections
- rebuild the compiled JavaScript bundle to keep the shipped assets in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced40b2d808330ac8a9922fc7b0fed