### PR TITLE
Update catechism resource links to new domain

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,7 +277,7 @@ function buildBibliaUrl(reference) {
   const path = `${normalizedBook}${chapter}${verseSegment ? `.${verseSegment}` : ""}`;
   return `https://biblia.com/books/esv/${path}`;
 }
-const CATECHISM_BASE_URL = "https://www.vatican.va/archive/ccc_css/archive/catechism/";
+const CATECHISM_BASE_URL = "http://www.scborromeo.org/ccc/";
 const CATECHISM_READINGS = [{
   slug: "p1s1c1a1",
   section: "Part One · Section One · Chapter One · Article 1",
@@ -440,7 +440,7 @@ const CATECHISM_READINGS = [{
   summary: "Perseverance, humility, and trust sustain us amid distractions and spiritual struggle."
 }].map(entry => ({
   ...entry,
-  url: `${CATECHISM_BASE_URL}${entry.slug}.htm`
+  url: `${CATECHISM_BASE_URL}${entry.slug}.htm${entry.anchor ? `#${entry.anchor}` : ""}`
 }));
 const SCRIPTURE_SEED_PLAN = SCRIPTURE_SEED_REFERENCES.map((reference, index) => ({
   reference: `${reference} (ESV)`,

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -670,7 +670,7 @@ function buildBibliaUrl(reference) {
   return `https://biblia.com/books/esv/${path}`;
 }
 
-const CATECHISM_BASE_URL = "https://www.vatican.va/archive/ccc_css/archive/catechism/";
+const CATECHISM_BASE_URL = "http://www.scborromeo.org/ccc/";
 
 const CATECHISM_READINGS = [
   {
@@ -867,7 +867,7 @@ const CATECHISM_READINGS = [
   },
 ].map((entry) => ({
   ...entry,
-  url: `${CATECHISM_BASE_URL}${entry.slug}.htm`,
+  url: `${CATECHISM_BASE_URL}${entry.slug}.htm${entry.anchor ? `#${entry.anchor}` : ""}`,
 }));
 
 const SCRIPTURE_SEED_PLAN = SCRIPTURE_SEED_REFERENCES.map((reference, index) => ({


### PR DESCRIPTION
## Summary
- point Catechism readings toward the new scborromeo.org host
- allow optional subsection anchors to be appended when building Catechism URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf277de1408330ba305cbf64855f42