### PR TITLE
Remove night silence practice

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,6 @@ const blankDay = date => ({
     angelus: false,
     magnificat: false,
     rosaryDecades: 0,
-    nightSilence: false,
     actOfContrition: false,
     gratitudePrayer: false
   },
@@ -685,13 +684,6 @@ const BASE_METRIC_OPTIONS = [{
   unit: "",
   weeklyUnit: "days",
   aggregate: SUM_AGGREGATE
-}, {
-  value: "nightSilence",
-  label: "Silence before sleep",
-  accessor: day => day.evening.nightSilence ? 1 : 0,
-  unit: "",
-  weeklyUnit: "days",
-  aggregate: SUM_AGGREGATE
 }];
 const METRIC_VIEW_OPTIONS = [{
   value: "daily",
@@ -735,7 +727,6 @@ const normalizeDay = (input = {}) => ({
     angelus: input.evening?.angelus ?? false,
     magnificat: input.evening?.magnificat ?? false,
     rosaryDecades: input.evening?.rosaryDecades ?? 0,
-    nightSilence: input.evening?.nightSilence ?? false,
     actOfContrition: input.evening?.actOfContrition ?? false,
     gratitudePrayer: input.evening?.gratitudePrayer ?? false
   },
@@ -769,7 +760,7 @@ function dayHasActivity(day) {
   if ((day.morning?.breathMinutes || 0) > 0) return true;
   if ((day.morning?.jesusPrayerCount || 0) > 0) return true;
   if (day.midday?.stillness || day.midday?.bodyBlessing) return true;
-  if (day.evening?.examen || day.evening?.nightSilence) return true;
+  if (day.evening?.examen) return true;
   if (day.evening?.magnificat) return true;
   if (day.evening?.actOfContrition) return true;
   if (day.evening?.gratitudePrayer) return true;
@@ -1669,7 +1660,12 @@ function App() {
       }
     }))
   }), /*#__PURE__*/React.createElement(ToggleRow, {
-    label: "Examen with Compassion",
+    label: /*#__PURE__*/React.createElement("a", {
+      href: "https://www.ignatianspirituality.com/ignatian-prayer/the-examen/how-can-i-pray/",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      className: "text-emerald-700 underline decoration-dotted underline-offset-2 transition hover:text-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-300 dark:hover:text-emerald-200"
+    }, "Examen with Compassion"),
     checked: d.evening.examen,
     onChange: v => setDay(date, x => ({
       ...x,
@@ -1678,6 +1674,9 @@ function App() {
         examen: v
       }
     }))
+  }), preferences.showGuidedPrompts && /*#__PURE__*/React.createElement(GuidedPrompt, {
+    title: "Gentle examen",
+    prompts: EXAMEN_PROMPTS
   }), /*#__PURE__*/React.createElement(StepperRow, {
     label: "Rosary (decades)",
     value: d.evening.rosaryDecades,
@@ -1692,19 +1691,6 @@ function App() {
     }))
   }), /*#__PURE__*/React.createElement(RosaryMysteryNote, {
     mystery: rosaryMystery
-  }), preferences.showGuidedPrompts && /*#__PURE__*/React.createElement(GuidedPrompt, {
-    title: "Gentle examen",
-    prompts: EXAMEN_PROMPTS
-  }), /*#__PURE__*/React.createElement(ToggleRow, {
-    label: "Silence Before Sleep",
-    checked: d.evening.nightSilence,
-    onChange: v => setDay(date, x => ({
-      ...x,
-      evening: {
-        ...x.evening,
-        nightSilence: v
-      }
-    }))
   }), /*#__PURE__*/React.createElement(ToggleRow, {
     label: /*#__PURE__*/React.createElement("a", {
       href: ACT_OF_CONTRITION_URL,
@@ -1925,10 +1911,6 @@ function App() {
   }, /*#__PURE__*/React.createElement("span", null, "Recite the Magnificat"), /*#__PURE__*/React.createElement("span", {
     className: "tabular-nums font-semibold"
   }, totals.eveningMagnificat)), /*#__PURE__*/React.createElement("div", {
-    className: "grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-2"
-  }, /*#__PURE__*/React.createElement("span", null, "Silence before sleep"), /*#__PURE__*/React.createElement("span", {
-    className: "tabular-nums font-semibold"
-  }, totals.eveningNightSilence)), /*#__PURE__*/React.createElement("div", {
     className: "grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-2"
   }, /*#__PURE__*/React.createElement("span", null, "Act of Contrition"), /*#__PURE__*/React.createElement("span", {
     className: "tabular-nums font-semibold"
@@ -2152,7 +2134,7 @@ function RecentEntryRow({
     month: "short",
     day: "numeric"
   });
-  const dailyFlags = [Boolean(day.morning?.consecration), Boolean(day.morning?.angelus), Boolean(day.morning?.benedictus), Boolean(day.midday?.stillness), Boolean(day.midday?.angelus), Boolean(day.midday?.bodyBlessing), Boolean(day.evening?.examen), Boolean(day.evening?.angelus), Boolean(day.evening?.magnificat), Boolean(day.evening?.nightSilence), Boolean(day.evening?.actOfContrition), Boolean(day.evening?.gratitudePrayer)];
+  const dailyFlags = [Boolean(day.morning?.consecration), Boolean(day.morning?.angelus), Boolean(day.morning?.benedictus), Boolean(day.midday?.stillness), Boolean(day.midday?.angelus), Boolean(day.midday?.bodyBlessing), Boolean(day.evening?.examen), Boolean(day.evening?.angelus), Boolean(day.evening?.magnificat), Boolean(day.evening?.actOfContrition), Boolean(day.evening?.gratitudePrayer)];
   const dailyCompleted = dailyFlags.filter(Boolean).length;
   const weeklyCompleted = WEEKLY_ANCHOR_KEYS.filter(key => day.weekly?.[key]).length;
   const weeklyCompletedNames = WEEKLY_ANCHOR_KEYS.filter(key => day.weekly?.[key]).map(key => WEEKLY_ANCHOR_LABELS[key] || key.charAt(0).toUpperCase() + key.slice(1));
@@ -2175,7 +2157,6 @@ function RecentEntryRow({
   if (day.evening?.examen) practiceBadges.push("🌙 Evening examen");
   if (day.evening?.angelus) practiceBadges.push("🔔 Evening Angelus");
   if (day.evening?.magnificat) practiceBadges.push("🎶 Magnificat");
-  if (day.evening?.nightSilence) practiceBadges.push("🌌 Night silence");
   if (day.evening?.actOfContrition) practiceBadges.push("🕯️ Act of Contrition");
   if (day.evening?.gratitudePrayer) practiceBadges.push("✨ Gratitude prayer");
   const customMetricChips = [];
@@ -3590,7 +3571,7 @@ function addDaysISO(dateISO, days) {
 }
 function anyPracticeDone(day) {
   if (!day) return false;
-  return day.morning.consecration || day.morning.angelus || day.morning.benedictus || day.morning.breathMinutes > 0 || day.morning.jesusPrayerCount > 0 || day.midday.stillness || day.midday.angelus || day.midday.bodyBlessing || day.evening.examen || day.evening.rosaryDecades > 0 || day.evening.angelus || day.evening.magnificat || day.evening.nightSilence || day.evening.actOfContrition || day.evening.gratitudePrayer;
+  return day.morning.consecration || day.morning.angelus || day.morning.benedictus || day.morning.breathMinutes > 0 || day.morning.jesusPrayerCount > 0 || day.midday.stillness || day.midday.angelus || day.midday.bodyBlessing || day.evening.examen || day.evening.rosaryDecades > 0 || day.evening.angelus || day.evening.magnificat || day.evening.actOfContrition || day.evening.gratitudePrayer;
 }
 function calcStreak(data) {
   let d = new Date();
@@ -3650,7 +3631,6 @@ function calcTotals(data) {
     if (evening.examen) acc.eveningExamen += 1;
     if (evening.angelus) acc.eveningAngelus += 1;
     if (evening.magnificat) acc.eveningMagnificat += 1;
-    if (evening.nightSilence) acc.eveningNightSilence += 1;
     if (evening.actOfContrition) acc.eveningActOfContrition += 1;
     if (evening.gratitudePrayer) acc.eveningGratitudePrayer += 1;
     if (weekly.mass) acc.weeklyMass += 1;
@@ -3678,7 +3658,6 @@ function calcTotals(data) {
     eveningExamen: 0,
     eveningAngelus: 0,
     eveningMagnificat: 0,
-    eveningNightSilence: 0,
     eveningActOfContrition: 0,
     eveningGratitudePrayer: 0,
     weeklyMass: 0,
@@ -3831,7 +3810,7 @@ function monthDots(dateISO, data) {
   return arr;
 }
 function toCSV(data, customMetrics = []) {
-  const header = ["Date", "Scripture", "Notes", "Consecration", "MorningAngelus", "MorningBenedictus", "BreathMinutes", "JesusPrayerCount", "Stillness", "MiddayAngelus", "BodyBlessing", "Examen", "EveningAngelus", "EveningMagnificat", "RosaryDecades", "NightSilence", "ActOfContrition", "GratitudePrayer", "UrgesNoted", "Victories", "Lapses", "Mass", "Adoration", "Confession", "Fasting", "Accountability", "Mood", "Tags"];
+  const header = ["Date", "Scripture", "Notes", "Consecration", "MorningAngelus", "MorningBenedictus", "BreathMinutes", "JesusPrayerCount", "Stillness", "MiddayAngelus", "BodyBlessing", "Examen", "EveningAngelus", "EveningMagnificat", "RosaryDecades", "ActOfContrition", "GratitudePrayer", "UrgesNoted", "Victories", "Lapses", "Mass", "Adoration", "Confession", "Fasting", "Accountability", "Mood", "Tags"];
   customMetrics.forEach(metric => header.push(metric.name || metric.id));
   const rows = [header.join(",")];
   const keys = Object.keys(data).sort();
@@ -3839,7 +3818,7 @@ function toCSV(data, customMetrics = []) {
     const day = data[k];
     const tags = Array.isArray(day.contextTags) ? day.contextTags.join(" ") : "";
     const mood = day.mood || "";
-    rows.push([day.date, csvQuote(day.scripture), csvQuote(day.notes), day.morning.consecration ? 1 : 0, day.morning.angelus ? 1 : 0, day.morning.benedictus ? 1 : 0, day.morning.breathMinutes, day.morning.jesusPrayerCount, day.midday.stillness ? 1 : 0, day.midday.angelus ? 1 : 0, day.midday.bodyBlessing ? 1 : 0, day.evening.examen ? 1 : 0, day.evening.angelus ? 1 : 0, day.evening.magnificat ? 1 : 0, day.evening.rosaryDecades, day.evening.nightSilence ? 1 : 0, day.evening.actOfContrition ? 1 : 0, day.evening.gratitudePrayer ? 1 : 0, day.temptations.urgesNoted, day.temptations.victories, day.temptations.lapses, day.weekly.mass ? 1 : 0, day.weekly.adoration ? 1 : 0, day.weekly.confession ? 1 : 0, day.weekly.fasting ? 1 : 0, day.weekly.accountability ? 1 : 0, mood, csvQuote(tags), ...customMetrics.map(metric => {
+    rows.push([day.date, csvQuote(day.scripture), csvQuote(day.notes), day.morning.consecration ? 1 : 0, day.morning.angelus ? 1 : 0, day.morning.benedictus ? 1 : 0, day.morning.breathMinutes, day.morning.jesusPrayerCount, day.midday.stillness ? 1 : 0, day.midday.angelus ? 1 : 0, day.midday.bodyBlessing ? 1 : 0, day.evening.examen ? 1 : 0, day.evening.angelus ? 1 : 0, day.evening.magnificat ? 1 : 0, day.evening.rosaryDecades, day.evening.actOfContrition ? 1 : 0, day.evening.gratitudePrayer ? 1 : 0, day.temptations.urgesNoted, day.temptations.victories, day.temptations.lapses, day.weekly.mass ? 1 : 0, day.weekly.adoration ? 1 : 0, day.weekly.confession ? 1 : 0, day.weekly.fasting ? 1 : 0, day.weekly.accountability ? 1 : 0, mood, csvQuote(tags), ...customMetrics.map(metric => {
       const raw = day.customMetrics?.[metric.id];
       return Number(raw ?? 0);
     })].join(","));

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -75,7 +75,6 @@ const blankDay = (date) => ({
     angelus: false,
     magnificat: false,
     rosaryDecades: 0,
-    nightSilence: false,
     actOfContrition: false,
     gratitudePrayer: false,
   },
@@ -1198,14 +1197,6 @@ const BASE_METRIC_OPTIONS = [
     weeklyUnit: "days",
     aggregate: SUM_AGGREGATE,
   },
-  {
-    value: "nightSilence",
-    label: "Silence before sleep",
-    accessor: (day) => (day.evening.nightSilence ? 1 : 0),
-    unit: "",
-    weeklyUnit: "days",
-    aggregate: SUM_AGGREGATE,
-  },
 ];
 
 const METRIC_VIEW_OPTIONS = [
@@ -1251,7 +1242,6 @@ const normalizeDay = (input = {}) => ({
     angelus: input.evening?.angelus ?? false,
     magnificat: input.evening?.magnificat ?? false,
     rosaryDecades: input.evening?.rosaryDecades ?? 0,
-    nightSilence: input.evening?.nightSilence ?? false,
     actOfContrition: input.evening?.actOfContrition ?? false,
     gratitudePrayer: input.evening?.gratitudePrayer ?? false,
   },
@@ -1286,7 +1276,7 @@ function dayHasActivity(day) {
   if ((day.morning?.breathMinutes || 0) > 0) return true;
   if ((day.morning?.jesusPrayerCount || 0) > 0) return true;
   if (day.midday?.stillness || day.midday?.bodyBlessing) return true;
-  if (day.evening?.examen || day.evening?.nightSilence) return true;
+  if (day.evening?.examen) return true;
   if (day.evening?.magnificat) return true;
   if (day.evening?.actOfContrition) return true;
   if (day.evening?.gratitudePrayer) return true;
@@ -2171,10 +2161,20 @@ function App() {
                   onChange={(v) => setDay(date, (x) => ({ ...x, evening: { ...x.evening, magnificat: v } }))}
                 />
                 <ToggleRow
-                  label="Examen with Compassion"
+                  label={
+                    <a
+                      href="https://www.ignatianspirituality.com/ignatian-prayer/the-examen/how-can-i-pray/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-emerald-700 underline decoration-dotted underline-offset-2 transition hover:text-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-300 dark:hover:text-emerald-200"
+                    >
+                      Examen with Compassion
+                    </a>
+                  }
                   checked={d.evening.examen}
                   onChange={(v) => setDay(date, (x) => ({ ...x, evening: { ...x.evening, examen: v } }))}
                 />
+                {preferences.showGuidedPrompts && <GuidedPrompt title="Gentle examen" prompts={EXAMEN_PROMPTS} />}
                 <StepperRow
                   label="Rosary (decades)"
                   value={d.evening.rosaryDecades}
@@ -2183,12 +2183,6 @@ function App() {
                   onChange={(n) => setDay(date, (x) => ({ ...x, evening: { ...x.evening, rosaryDecades: n } }))}
                 />
                 <RosaryMysteryNote mystery={rosaryMystery} />
-                {preferences.showGuidedPrompts && <GuidedPrompt title="Gentle examen" prompts={EXAMEN_PROMPTS} />}
-                <ToggleRow
-                  label="Silence Before Sleep"
-                  checked={d.evening.nightSilence}
-                  onChange={(v) => setDay(date, (x) => ({ ...x, evening: { ...x.evening, nightSilence: v } }))}
-                />
                 <ToggleRow
                   label={
                     <a
@@ -2428,10 +2422,6 @@ function App() {
                       <div className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-2">
                         <span>Recite the Magnificat</span>
                         <span className="tabular-nums font-semibold">{totals.eveningMagnificat}</span>
-                      </div>
-                      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-2">
-                        <span>Silence before sleep</span>
-                        <span className="tabular-nums font-semibold">{totals.eveningNightSilence}</span>
                       </div>
                       <div className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-2">
                         <span>Act of Contrition</span>
@@ -2712,7 +2702,6 @@ function RecentEntryRow({ day, onSelectDate, customMetricMap }) {
     Boolean(day.evening?.examen),
     Boolean(day.evening?.angelus),
     Boolean(day.evening?.magnificat),
-    Boolean(day.evening?.nightSilence),
     Boolean(day.evening?.actOfContrition),
     Boolean(day.evening?.gratitudePrayer),
   ];
@@ -2749,7 +2738,6 @@ function RecentEntryRow({ day, onSelectDate, customMetricMap }) {
   if (day.evening?.examen) practiceBadges.push("🌙 Evening examen");
   if (day.evening?.angelus) practiceBadges.push("🔔 Evening Angelus");
   if (day.evening?.magnificat) practiceBadges.push("🎶 Magnificat");
-  if (day.evening?.nightSilence) practiceBadges.push("🌌 Night silence");
   if (day.evening?.actOfContrition) practiceBadges.push("🕯️ Act of Contrition");
   if (day.evening?.gratitudePrayer) practiceBadges.push("✨ Gratitude prayer");
 
@@ -4224,7 +4212,6 @@ function anyPracticeDone(day) {
     day.evening.rosaryDecades > 0 ||
     day.evening.angelus ||
     day.evening.magnificat ||
-    day.evening.nightSilence ||
     day.evening.actOfContrition ||
     day.evening.gratitudePrayer
   );
@@ -4299,7 +4286,6 @@ function calcTotals(data) {
       if (evening.examen) acc.eveningExamen += 1;
       if (evening.angelus) acc.eveningAngelus += 1;
       if (evening.magnificat) acc.eveningMagnificat += 1;
-      if (evening.nightSilence) acc.eveningNightSilence += 1;
       if (evening.actOfContrition) acc.eveningActOfContrition += 1;
       if (evening.gratitudePrayer) acc.eveningGratitudePrayer += 1;
 
@@ -4330,7 +4316,6 @@ function calcTotals(data) {
       eveningExamen: 0,
       eveningAngelus: 0,
       eveningMagnificat: 0,
-      eveningNightSilence: 0,
       eveningActOfContrition: 0,
       eveningGratitudePrayer: 0,
       weeklyMass: 0,
@@ -4493,7 +4478,6 @@ function toCSV(data, customMetrics = []) {
     "EveningAngelus",
     "EveningMagnificat",
     "RosaryDecades",
-    "NightSilence",
     "ActOfContrition",
     "GratitudePrayer",
     "UrgesNoted",
@@ -4531,7 +4515,6 @@ function toCSV(data, customMetrics = []) {
         day.evening.angelus ? 1 : 0,
         day.evening.magnificat ? 1 : 0,
         day.evening.rosaryDecades,
-        day.evening.nightSilence ? 1 : 0,
         day.evening.actOfContrition ? 1 : 0,
         day.evening.gratitudePrayer ? 1 : 0,
         day.temptations.urgesNoted,


### PR DESCRIPTION
## Summary
- remove the Silence before sleep toggle from the evening section and totals views
- update day normalization, metrics, streak logic, and CSV export to stop tracking the night silence field

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cf383fd6508330aee5625d1e3629ae