### PR TITLE
Play chime when meditation timer starts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1345,7 +1345,6 @@ function App() {
   }, [streak, showAffirmation]);
   const handleBeginSession = useCallback(() => {
     setShowSessionModal(true);
-    void playChime();
     if (timerCardRef.current && typeof timerCardRef.current.scrollIntoView === "function") {
       timerCardRef.current.scrollIntoView({
         behavior: "smooth",
@@ -2555,6 +2554,12 @@ function MeditationTimer({
     }
     setSeconds(0);
   };
+  const handleToggle = () => {
+    if (!running && seconds === 0) {
+      void playChime();
+    }
+    setRunning(r => !r);
+  };
   return /*#__PURE__*/React.createElement("div", {
     className: "flex flex-col items-center gap-3"
   }, /*#__PURE__*/React.createElement("div", {
@@ -2563,7 +2568,7 @@ function MeditationTimer({
     className: "flex gap-2"
   }, /*#__PURE__*/React.createElement("button", {
     className: "btn",
-    onClick: () => setRunning(r => !r)
+    onClick: handleToggle
   }, running ? "Pause" : seconds ? "Resume" : "Start"), /*#__PURE__*/React.createElement("button", {
     className: "btn",
     onClick: reset,

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1836,7 +1836,6 @@ function App() {
 
   const handleBeginSession = useCallback(() => {
     setShowSessionModal(true);
-    void playChime();
     if (timerCardRef.current && typeof timerCardRef.current.scrollIntoView === "function") {
       timerCardRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
     }
@@ -3184,13 +3183,20 @@ function MeditationTimer({ onFinish }) {
     setSeconds(0);
   };
 
+  const handleToggle = () => {
+    if (!running && seconds === 0) {
+      void playChime();
+    }
+    setRunning((r) => !r);
+  };
+
   return (
     <div className="flex flex-col items-center gap-3">
       <div className="text-4xl font-mono tabular-nums">
         {String(mins).padStart(2, "0")}:{String(secs).padStart(2, "0")}
       </div>
       <div className="flex gap-2">
-        <button className="btn" onClick={() => setRunning((r) => !r)}>
+        <button className="btn" onClick={handleToggle}>
           {running ? "Pause" : seconds ? "Resume" : "Start"}
         </button>
         <button className="btn" onClick={reset} disabled={running}>


### PR DESCRIPTION
## Summary
- stop playing the meditation chime when the prayer session modal opens
- trigger the chime when the meditation timer starts from an idle state
- rebuild the compiled JavaScript bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d007d7fc70833088b33c77955553d2