### PR TITLE
Update Biblia URL for suggested readings

### DIFF
--- a/app.js
+++ b/app.js
@@ -330,7 +330,7 @@ function buildBibliaUrl(reference) {
   if (!normalizedBook || !chapter) return null;
   const verseSegment = verse.replace(/\s+/g, "");
   const path = `${normalizedBook}${chapter}${verseSegment ? `.${verseSegment}` : ""}`;
-  return `https://biblia.com/books/esv/${path}`;
+  return `https://biblia.com/bible/esv/${path}`;
 }
 const CATECHISM_BASE_URL = "http://www.scborromeo.org/ccc/";
 const CATECHISM_READINGS = [{

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -747,7 +747,7 @@ function buildBibliaUrl(reference) {
   if (!normalizedBook || !chapter) return null;
   const verseSegment = verse.replace(/\s+/g, "");
   const path = `${normalizedBook}${chapter}${verseSegment ? `.${verseSegment}` : ""}`;
-  return `https://biblia.com/books/esv/${path}`;
+  return `https://biblia.com/bible/esv/${path}`;
 }
 
 const CATECHISM_BASE_URL = "http://www.scborromeo.org/ccc/";


### PR DESCRIPTION
## Summary
- update the Biblia link generator to use the new /bible/esv/ base path for suggested Scripture readings
- rebuild the compiled JavaScript bundle to reflect the updated link root

## Testing
- npm run build:js

------
https://chatgpt.com/codex/tasks/task_e_68d11c3363288330b78a4dcdd1f4fa53